### PR TITLE
Introduce collections for addresses to the MessageBase and maintain compatibility

### DIFF
--- a/src/Postmark.Tests/PostmarkMessageTests.cs
+++ b/src/Postmark.Tests/PostmarkMessageTests.cs
@@ -216,5 +216,41 @@ namespace Postmark.Tests
 
         }
 
+
+        [Fact]
+        public void TestMissingCollectionItems()
+        {
+            var message = new PostmarkMessage()
+            {
+                From = singleFromAddress,
+                To = singleToAddress,
+                Subject = "Basic message setup",
+                HtmlBody = "This is <b>HTML</b> text.",
+                TextBody = "This is plain text.",
+                TrackOpens = true,
+                TrackLinks = LinkTrackingOptions.HtmlAndText,
+                Tag = "message-setup-testing"
+            };
+
+
+            string addressAdd = "test-addAddress@example.com";
+            string addressAdd2 = "    ";
+            //string addressAdd3 = "test-addAddress2@example.com";
+
+            Assert.Equal(0, message.CcAddressSet.Count);
+            Assert.Equal(0, message.BccAddressSet.Count);
+            Assert.Equal(0, message.Cc.Length);
+            Assert.Equal(0, message.Bcc.Length);
+
+            message.Cc = addressAdd;
+            message.Bcc = addressAdd2;
+
+            Assert.Equal(1, message.CcAddressSet.Count);
+            Assert.Equal(0, message.BccAddressSet.Count);
+            Assert.Equal(addressAdd.Length, message.Cc.Length);
+            Assert.Equal(0, message.Bcc.Length);
+
+        }
+
     }
 }

--- a/src/Postmark.Tests/PostmarkMessageTests.cs
+++ b/src/Postmark.Tests/PostmarkMessageTests.cs
@@ -1,0 +1,178 @@
+﻿using PostmarkDotNet;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using System.Linq;
+
+namespace Postmark.Tests
+{
+    public class PostmarkMessageTests
+    {
+        string singleFromAddress = "test-from@postmark.net";
+        string singleToAddress = "atest-to@example.com";
+        string singleCcAddress = "atest-cc@example.com";
+        string singleBccAddress = "atest-bcc@example.com";
+
+        [Fact]
+        public void BasicMessageSetupWithCollectionValidation()
+        {
+            var message = new PostmarkMessage()
+            {
+                From = singleFromAddress,
+                To = singleToAddress,
+                Cc = singleCcAddress,
+                Bcc = singleBccAddress,
+                Subject = "Basic message setup",
+                HtmlBody = "This is <b>HTML</b> text.",
+                TextBody = "This is plain text.",
+                TrackOpens = true,
+                TrackLinks = LinkTrackingOptions.HtmlAndText,
+                Tag = "message-setup-testing"
+            };
+
+            Assert.Equal(singleToAddress, message.To);
+            Assert.Equal(singleToAddress, message.ToAddressSet.Single());
+
+            Assert.Equal(singleCcAddress, message.Cc);
+            Assert.Equal(singleCcAddress, message.CcAddressSet.Single());
+
+            Assert.Equal(singleBccAddress, message.Bcc);
+            Assert.Equal(singleBccAddress, message.BccAddressSet.Single());
+
+        }
+
+        [Fact]
+        public void MessageSetupWithAddressAdditions()
+        {
+            var message = new PostmarkMessage()
+            {
+                From = singleFromAddress,
+                To = singleToAddress,
+                Cc = singleCcAddress,
+                Bcc = singleBccAddress,
+                Subject = "Basic message setup",
+                HtmlBody = "This is <b>HTML</b> text.",
+                TextBody = "This is plain text.",
+                TrackOpens = true,
+                TrackLinks = LinkTrackingOptions.HtmlAndText,
+                Tag = "message-setup-testing"
+            };
+
+            string addressAdd = "test-addAddress@example.com";
+            string addressAddDirty = "test-addAddress@example.com   ";
+
+            //Test for To
+            message.ToAddressSet.Add(addressAdd);
+            Assert.NotEqual(singleToAddress, message.To);
+            Assert.Contains(singleToAddress, message.To);
+            Assert.Contains(addressAdd, message.To);
+
+            //This is not safe as HashSet in the Framework does not guarantee ordering of output, replaced with contains below
+            //Assert.Equal(singleToAddress + "," + addressAdd, message.To);
+
+            message.To = addressAddDirty;
+            Assert.Equal(addressAdd, message.To);
+            
+            message.ToAddressSet.Clear();
+            message.ToAddressSet.Add(addressAddDirty);
+            message.ToAddressSet.Add(singleToAddress);
+
+            //This is not safe as HashSet in the Framework does not guarantee ordering of output, replaced with contains below
+            //Assert.Equal(addressAdd + "," + singleToAddress, message.To);
+
+            Assert.DoesNotContain(addressAddDirty, message.To);
+            Assert.Contains(addressAdd, message.To);
+
+            //Test for CC
+            message.CcAddressSet.Add(addressAdd);
+            Assert.NotEqual(singleCcAddress, message.Cc);
+
+            //This is not safe as HashSet in the Framework does not guarantee ordering of output, replaced with contains below
+            //Assert.Equal(singleCcAddress + "," + addressAdd, message.Cc);
+            Assert.Contains(singleCcAddress, message.Cc);
+            Assert.Contains(addressAdd, message.Cc);
+
+
+
+            //Test for BCC
+            message.BccAddressSet.Add(addressAdd);
+            Assert.NotEqual(singleBccAddress, message.Bcc);
+            
+            //This is not safe as HashSet in the Framework does not guarantee ordering of output, replaced with contains below
+            //Assert.Equal(singleBccAddress + "," + addressAdd, message.Bcc);
+
+            Assert.Contains(singleBccAddress, message.Bcc);
+            Assert.Contains(addressAdd, message.Bcc);
+            
+        }
+
+        [Fact]
+        public void MessageSetupWithAddressRemoval()
+        {
+            var message = new PostmarkMessage()
+            {
+                From = singleFromAddress,
+                To = singleToAddress,
+                Cc = singleCcAddress,
+                Bcc = singleBccAddress,
+                Subject = "Basic message setup",
+                HtmlBody = "This is <b>HTML</b> text.",
+                TextBody = "This is plain text.",
+                TrackOpens = true,
+                TrackLinks = LinkTrackingOptions.HtmlAndText,
+                Tag = "message-setup-testing"
+            };
+
+            string addressAdd = "test-addAddress@example.com";
+            string addressAdd2 = "test-addAddress2@example.com";
+
+            message.ToAddressSet.Add(addressAdd);
+            message.ToAddressSet.Add(addressAdd2);
+
+            message.ToAddressSet.Remove(singleToAddress);
+
+            Assert.Contains(addressAdd, message.To);
+            Assert.Contains(addressAdd2, message.To);
+            Assert.DoesNotContain(singleToAddress, message.To);
+            
+        }
+
+        [Fact]
+        public void MessageSetupWithEmptyAddressAddition()
+        {
+            var message = new PostmarkMessage()
+            {
+                From = singleFromAddress,
+                To = singleToAddress,
+                Cc = singleCcAddress,
+                Bcc = singleBccAddress,
+                Subject = "Basic message setup",
+                HtmlBody = "This is <b>HTML</b> text.",
+                TextBody = "This is plain text.",
+                TrackOpens = true,
+                TrackLinks = LinkTrackingOptions.HtmlAndText,
+                Tag = "message-setup-testing"
+            };
+
+            string addressAdd = "test-addAddress@example.com";
+            string addressAdd2 = "    ";
+            string addressAdd3 = "test-addAddress2@example.com";
+
+            message.ToAddressSet.Add(addressAdd);
+            message.ToAddressSet.Add(addressAdd2);
+            message.ToAddressSet.Add(addressAdd3);
+
+            Assert.Contains(addressAdd, message.To);
+            Assert.Contains(addressAdd3, message.To);
+
+            //Message should not contain the blank space
+            Assert.DoesNotContain(addressAdd2, message.To);
+
+            //Message should not contain multiple commas with no address between them
+            Assert.DoesNotContain(",,", message.To);
+
+        }
+
+    }
+}

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Postmark.Utility;
 
 namespace PostmarkDotNet
 {
@@ -27,17 +28,63 @@ namespace PostmarkDotNet
         /// <summary>
         ///   Any recipients. Separate multiple recipients with a comma.
         /// </summary>
-        public string To { get; set; }
+        public string To
+        {
+            get
+            {
+                return string.Join(",", StringUtils.TrimStringEnum(ToAddressSet));
+            }
+            set
+            {
+                ToAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(value.Split(',')));
+            }
+        }
+
+        /// <summary>
+        ///   "To" Recipients organized as a collection, interfaced to the BCC field for compatibility
+        /// </summary>
+        public HashSet<string> ToAddressSet { get; set; }
 
         /// <summary>
         ///   Any CC recipients. Separate multiple recipients with a comma.
         /// </summary>
-        public string Cc { get; set; }
+        public string Cc
+        {
+            get
+            {
+                return string.Join(",", StringUtils.TrimStringEnum(CcAddressSet));
+            }
+            set
+            {
+                CcAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(value.Split(',')));
+            }
+        }
+
+
+        /// <summary>
+        ///   "CC" Recipients organized as a collection, interfaced to the BCC field for compatibility
+        /// </summary>
+        public HashSet<string> CcAddressSet { get; set; }
 
         /// <summary>
         ///   Any BCC recipients. Separate multiple recipients with a comma.
         /// </summary>
-        public string Bcc { get; set; }
+        public string Bcc
+        {
+            get
+            {
+                return string.Join(",", StringUtils.TrimStringEnum(BccAddressSet));
+            }
+            set
+            {
+                BccAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(value.Split(',')));
+            }
+        }
+
+        /// <summary>
+        ///   "BCC" Recipients organized as a collection, interfaced to the BCC field for compatibility
+        /// </summary>
+        public HashSet<string> BccAddressSet { get; set; }
 
         /// <summary>
         ///   The email address to reply to. This is optional.

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -19,6 +19,9 @@ namespace PostmarkDotNet
         {
             Attachments = new List<PostmarkMessageAttachment>(0);
             TrackLinks = LinkTrackingOptions.None;
+            ToAddressSet = new HashSet<string>();
+            CcAddressSet = new HashSet<string>();
+            BccAddressSet = new HashSet<string>();
         }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Postmark.Utility;
+using System.Text.RegularExpressions;
 
 namespace PostmarkDotNet
 {
@@ -36,7 +37,7 @@ namespace PostmarkDotNet
             }
             set
             {
-                ToAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(value.Split(',')));
+                ToAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(Regex.Split(value, @",(?=(?:[^\""]*\""[^\""]*\"")*(?![^\""]*\""))")));
             }
         }
 
@@ -56,7 +57,7 @@ namespace PostmarkDotNet
             }
             set
             {
-                CcAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(value.Split(',')));
+                CcAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(Regex.Split(value, @",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))")));
             }
         }
 
@@ -77,7 +78,7 @@ namespace PostmarkDotNet
             }
             set
             {
-                BccAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(value.Split(',')));
+                BccAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(Regex.Split(value, @",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))")));
             }
         }
 

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -57,7 +57,7 @@ namespace PostmarkDotNet
             }
             set
             {
-                CcAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(Regex.Split(value, @",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))")));
+                CcAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(Regex.Split(value, @",(?=(?:[^\""]*\""[^\""]*\"")*(?![^\""]*\""))")));
             }
         }
 
@@ -78,7 +78,7 @@ namespace PostmarkDotNet
             }
             set
             {
-                BccAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(Regex.Split(value, @",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))")));
+                BccAddressSet = new HashSet<string>(StringUtils.TrimStringEnum(Regex.Split(value, @",(?=(?:[^\""]*\""[^\""]*\"")*(?![^\""]*\""))")));
             }
         }
 

--- a/src/Postmark/Utility/StringUtils.cs
+++ b/src/Postmark/Utility/StringUtils.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Postmark.Utility
+{
+    internal static class StringUtils
+    {
+        /// <summary>
+        ///   Takes an IEnumerable and returns an IEnumerable that has whitespace trimmed for all entries and doesn't include items with whitespace only
+        /// </summary>
+        internal static IEnumerable<string> TrimStringEnum(IEnumerable<string> input)
+        {
+            if (input == null)
+                return null;
+
+            List<string> output = new List<string>(input.Count());
+
+            foreach (var p in input)
+            {
+                string result = p.Trim();
+                if (!string.IsNullOrWhiteSpace(result))
+                    output.Add(result);
+            }
+
+            return output;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds collections for the addresses which support multiple recipients (per the blog post here: https://postmarkapp.com/blog/postmark-now-with-multiple-recipients-support).  Now that multiple addresses are available, providing native collections for management makes significantly more sense as it reduces the need for users to chop up strings manually in the case that their application logic needs to rewrite or remove individual addresses out of a set.

This approach specifically maintains compatibility with existing code by introducing property code which seamlessly translates between the original fields and the now-backing collection.

Test cases for the code is also included to ensure that future changes are validated appropriately.