### PR TITLE
Non-static client factory

### DIFF
--- a/src/Postmark/PostmarkAdminClient.cs
+++ b/src/Postmark/PostmarkAdminClient.cs
@@ -19,6 +19,7 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="accountToken">The "accountToken" can be found by logging into your Postmark and navigating to https://postmarkapp.com/account/edit - Keep this token secret and safe.</param>
         /// <param name="apiBaseUri">Optionally override the base url to the API. For example, you may fallback to HTTP (non-SSL) if your app requires it, though, this is not recommended.</param>
+        /// <param name="client"><see cref="ISimpleHttpClient"/> to processes HTTP interactions.</param>
         public PostmarkAdminClient(string accountToken, string apiBaseUri = "https://api.postmarkapp.com", ISimpleHttpClient client = null)
             : base(apiBaseUri, client)
         {

--- a/src/Postmark/PostmarkAdminClient.cs
+++ b/src/Postmark/PostmarkAdminClient.cs
@@ -19,8 +19,8 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="accountToken">The "accountToken" can be found by logging into your Postmark and navigating to https://postmarkapp.com/account/edit - Keep this token secret and safe.</param>
         /// <param name="apiBaseUri">Optionally override the base url to the API. For example, you may fallback to HTTP (non-SSL) if your app requires it, though, this is not recommended.</param>
-        public PostmarkAdminClient(string accountToken, string apiBaseUri = "https://api.postmarkapp.com")
-            : base(apiBaseUri)
+        public PostmarkAdminClient(string accountToken, string apiBaseUri = "https://api.postmarkapp.com", ISimpleHttpClient client = null)
+            : base(apiBaseUri, client)
         {
             _authToken = accountToken;
         }
@@ -112,7 +112,7 @@ namespace PostmarkDotNet
         public async Task<PostmarkServer> EditServerAsync(int serverId, String name = null, string color = null,
             bool? rawEmailEnabled = null, bool? smtpApiActivated = null, string inboundHookUrl = null,
             string bounceHookUrl = null, string openHookUrl = null, bool? postFirstOpenOnly = null,
-            bool? trackOpens = null, string inboundDomain = null, int? inboundSpamThreshold = null, 
+            bool? trackOpens = null, string inboundDomain = null, int? inboundSpamThreshold = null,
             LinkTrackingOptions? trackLinks = null, string clickHookUrl = null, string deliveryHookUrl = null, bool? enableSmtpApiErrorHooks = null)
         {
 

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -33,8 +33,8 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="apiBaseUri">The base uri to use when connecting to Postmark. You should rarely need to modify this, except if you want to disable TLS (not recommended), or you are using a proxy of some sort to connect to the API.</param>
         /// <param name="serverToken">Used for requests that require server level privileges. This token can be found on the Credentials tab under your Postmark server.</param>
-        public PostmarkClient(string serverToken, string apiBaseUri = "https://api.postmarkapp.com")
-            : base(apiBaseUri)
+        public PostmarkClient(string serverToken, string apiBaseUri = "https://api.postmarkapp.com", ISimpleHttpClient client = null)
+            : base(apiBaseUri, client)
         {
             _authToken = serverToken;
         }

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -33,6 +33,7 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="apiBaseUri">The base uri to use when connecting to Postmark. You should rarely need to modify this, except if you want to disable TLS (not recommended), or you are using a proxy of some sort to connect to the API.</param>
         /// <param name="serverToken">Used for requests that require server level privileges. This token can be found on the Credentials tab under your Postmark server.</param>
+        /// <param name="client"><see cref="ISimpleHttpClient"/> to processes HTTP interactions.</param>
         public PostmarkClient(string serverToken, string apiBaseUri = "https://api.postmarkapp.com", ISimpleHttpClient client = null)
             : base(apiBaseUri, client)
         {

--- a/src/Postmark/PostmarkClientBase.cs
+++ b/src/Postmark/PostmarkClientBase.cs
@@ -14,19 +14,6 @@ namespace PostmarkDotNet
     /// </summary>
     public abstract class PostmarkClientBase
     {
-        private static Lazy<ISimpleHttpClient> _staticClient = 
-            new Lazy<ISimpleHttpClient>(()=>new SimpleHttpClient()) ;
-
-        /// <summary>
-        /// Configure a global connection factory to to process HTTP interactions.
-        /// </summary>
-        /// <remarks>
-        /// In most cases, you should not need to modify this property, but it's useful
-        /// in cases where you want to use another http client, or to mock the http processing
-        /// (for tests).
-        /// </remarks>
-        public static Func<ISimpleHttpClient> ClientFactory {get;set;} = () => _staticClient.Value;
-
         protected static readonly string DATE_FORMAT = "yyyy-MM-dd";
 
         /// <summary>
@@ -38,6 +25,7 @@ namespace PostmarkDotNet
               typeof(PostmarkClient).AssemblyQualifiedName + ")";
 
         private Uri baseUri;
+        private readonly ISimpleHttpClient client;
 
         /// <summary>
         /// Provides a base implementation of core request/response interactions.
@@ -47,6 +35,7 @@ namespace PostmarkDotNet
         public PostmarkClientBase(string apiBaseUri = "https://api.postmarkapp.com", ISimpleHttpClient client = null)
         {
             baseUri = new Uri(apiBaseUri);
+            this.client = client ?? new SimpleHttpClient();
         }
 
         protected abstract string AuthHeaderName { get; }
@@ -68,8 +57,6 @@ namespace PostmarkDotNet
         {
             TResponse retval = default(TResponse);
 
-            var client = ClientFactory();
-            
             var request = new HttpRequestMessage(verb, baseUri + apiPath.TrimStart('/'));
 
             //if the message is not a string, or the message is a non-empty string,

--- a/src/Postmark/PostmarkClientBase.cs
+++ b/src/Postmark/PostmarkClientBase.cs
@@ -31,7 +31,7 @@ namespace PostmarkDotNet
         /// Provides a base implementation of core request/response interactions.
         /// </summary>
         /// <param name="apiBaseUri"></param>
-        /// <param name="requestTimeoutInSeconds"></param>
+        /// <param name="client"><see cref="ISimpleHttpClient"/> to processes HTTP interactions.</param>
         public PostmarkClientBase(string apiBaseUri = "https://api.postmarkapp.com", ISimpleHttpClient client = null)
         {
             baseUri = new Uri(apiBaseUri);

--- a/src/Postmark/PostmarkClientBase.cs
+++ b/src/Postmark/PostmarkClientBase.cs
@@ -44,7 +44,7 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="apiBaseUri"></param>
         /// <param name="requestTimeoutInSeconds"></param>
-        public PostmarkClientBase(string apiBaseUri = "https://api.postmarkapp.com")
+        public PostmarkClientBase(string apiBaseUri = "https://api.postmarkapp.com", ISimpleHttpClient client = null)
         {
             baseUri = new Uri(apiBaseUri);
         }


### PR DESCRIPTION
Microsoft advises that we should `IHttpClientFactory` to implement resilient HTTP requests (see [docs](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests)). For this to happen, the `HttpClient` needs to be provided when creating instances of `PostmarkClient` or `PostmarkAdminClient`.

In this PR, the static client factory is replaced with an optional `ISimpleHttpClient` parameter. This works for scenarios where the injection of `HttpClient` instances is (and is not) preferred.