### PR TITLE
Compatibility with System.Text.Json enumerable converter

### DIFF
--- a/src/Postmark/Model/LinkTrackingOptions.cs
+++ b/src/Postmark/Model/LinkTrackingOptions.cs
@@ -1,7 +1,7 @@
 ﻿namespace PostmarkDotNet
 {
     [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
+    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<LinkTrackingOptions>))]
     public enum LinkTrackingOptions
     {
         None = 0,

--- a/src/Postmark/Model/LinkTrackingOptions.cs
+++ b/src/Postmark/Model/LinkTrackingOptions.cs
@@ -1,9 +1,7 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-
-namespace PostmarkDotNet
+﻿namespace PostmarkDotNet
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
     public enum LinkTrackingOptions
     {
         None = 0,

--- a/src/Postmark/Model/MessageStreams/PostmarkMessageStream.cs
+++ b/src/Postmark/Model/MessageStreams/PostmarkMessageStream.cs
@@ -33,7 +33,7 @@ namespace Postmark.Model.MessageStreams
         /// The type of this message Stream. Can be Transactional, Inbound or Broadcasts.
         /// </summary>
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<MessageStreamType>))]
         public MessageStreamType MessageStreamType { get; set; }
 
         /// <summary>

--- a/src/Postmark/Model/MessageStreams/PostmarkMessageStream.cs
+++ b/src/Postmark/Model/MessageStreams/PostmarkMessageStream.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using PostmarkDotNet;
 
 namespace Postmark.Model.MessageStreams
 {
@@ -33,25 +32,26 @@ namespace Postmark.Model.MessageStreams
         /// <summary>
         /// The type of this message Stream. Can be Transactional, Inbound or Broadcasts.
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
         public MessageStreamType MessageStreamType { get; set; }
 
         /// <summary>
         /// The date when the message stream was created.
         /// </summary>
-        [JsonConverter(typeof(IsoDateTimeConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.IsoDateTimeConverter))]
         public DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// The date when the message stream was last updated. If null, this message stream was never updated.
         /// </summary>
-        [JsonConverter(typeof(IsoDateTimeConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.IsoDateTimeConverter))]
         public DateTime? UpdatedAt { get; set; }
 
         /// <summary>
         /// The date when this message stream has been archived. If null, this message stream is not in an archival state.
         /// </summary>
-        [JsonConverter(typeof(IsoDateTimeConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.IsoDateTimeConverter))]
         public DateTime? ArchivedAt { get; set; }
     }
 }

--- a/src/Postmark/Model/PostmarkBounce.cs
+++ b/src/Postmark/Model/PostmarkBounce.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System;
+﻿using System;
 
 namespace PostmarkDotNet
 {
@@ -20,7 +18,8 @@ namespace PostmarkDotNet
         ///   The <see cref = "PostmarkBounceType" /> for this bounce.
         /// </summary>
         /// <value>The type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
         public PostmarkBounceType Type { get; set; }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkBounceSummary.cs
+++ b/src/Postmark/Model/PostmarkBounceSummary.cs
@@ -1,7 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-
-namespace PostmarkDotNet
+﻿namespace PostmarkDotNet
 {
     /// <summary>
     ///   Represents an aggregate view of bounces.
@@ -12,7 +9,8 @@ namespace PostmarkDotNet
         ///   An summary for a <see cref = "PostmarkBounceType" />.
         /// </summary>
         /// <value>The type.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
         public PostmarkBounceType Type { get; set; }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkTemplate.cs
+++ b/src/Postmark/Model/PostmarkTemplate.cs
@@ -1,7 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-
-namespace PostmarkDotNet.Model
+﻿namespace PostmarkDotNet.Model
 {
     public class PostmarkTemplate
     {
@@ -21,7 +18,8 @@ namespace PostmarkDotNet.Model
 
         public bool Active { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
         public TemplateType TemplateType { get; set; }
 
         public string LayoutTemplate { get; set; }

--- a/src/Postmark/Model/PostmarkTemplate.cs
+++ b/src/Postmark/Model/PostmarkTemplate.cs
@@ -19,7 +19,7 @@
         public bool Active { get; set; }
 
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<TemplateType>))]
         public TemplateType TemplateType { get; set; }
 
         public string LayoutTemplate { get; set; }

--- a/src/Postmark/Model/PostmarkTemplateListingResponse.cs
+++ b/src/Postmark/Model/PostmarkTemplateListingResponse.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace PostmarkDotNet.Model
 {
@@ -22,7 +20,8 @@ namespace PostmarkDotNet.Model
 
         public string Alias { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
         public TemplateType TemplateType { get; set; }
 
         public string LayoutTemplate { get; set; }

--- a/src/Postmark/Model/PostmarkTemplateListingResponse.cs
+++ b/src/Postmark/Model/PostmarkTemplateListingResponse.cs
@@ -21,7 +21,7 @@ namespace PostmarkDotNet.Model
         public string Alias { get; set; }
 
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<TemplateType>))]
         public TemplateType TemplateType { get; set; }
 
         public string LayoutTemplate { get; set; }

--- a/src/Postmark/Model/Suppressions/PostmarkReactivationRequestResult.cs
+++ b/src/Postmark/Model/Suppressions/PostmarkReactivationRequestResult.cs
@@ -16,7 +16,7 @@ namespace Postmark.Model.Suppressions
         /// Status of the request.
         /// </summary>
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkReactivationRequestStatus>))]
         public PostmarkReactivationRequestStatus Status { get; set; }
 
         /// <summary>

--- a/src/Postmark/Model/Suppressions/PostmarkReactivationRequestResult.cs
+++ b/src/Postmark/Model/Suppressions/PostmarkReactivationRequestResult.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+﻿using PostmarkDotNet;
 
 namespace Postmark.Model.Suppressions
 {
@@ -16,7 +15,8 @@ namespace Postmark.Model.Suppressions
         /// <summary>
         /// Status of the request.
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
         public PostmarkReactivationRequestStatus Status { get; set; }
 
         /// <summary>

--- a/src/Postmark/Model/Suppressions/PostmarkSuppressionRequestResult.cs
+++ b/src/Postmark/Model/Suppressions/PostmarkSuppressionRequestResult.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+﻿using PostmarkDotNet;
 
 namespace Postmark.Model.Suppressions
 {
@@ -16,7 +15,8 @@ namespace Postmark.Model.Suppressions
         /// <summary>
         /// Status of the request.
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
         public PostmarkSuppressionRequestStatus Status { get; set; }
 
         /// <summary>

--- a/src/Postmark/Model/Suppressions/PostmarkSuppressionRequestResult.cs
+++ b/src/Postmark/Model/Suppressions/PostmarkSuppressionRequestResult.cs
@@ -16,7 +16,7 @@ namespace Postmark.Model.Suppressions
         /// Status of the request.
         /// </summary>
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkBounceType>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PostmarkSuppressionRequestStatus>))]
         public PostmarkSuppressionRequestStatus Status { get; set; }
 
         /// <summary>

--- a/src/Postmark/Postmark.csproj
+++ b/src/Postmark/Postmark.csproj
@@ -13,7 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This update makes the necessary changes to enable compatibility with the System.Text.Json enumerable converter that is the .NET pipeline default in .NET Core 3.1 and later.  In .NET Core 3.1, the default project templates and pipeline was adjusted to remove the requirement for Newtonsoft.Json and make the new integrated System.Text.Json library the default.  This ensures that the webhook model can be used out of the box with current ASP.NET default project templates and settings.

Note that the change retains compatibility with the older Newtonsoft.Json binder as well by fully qualifying both references, so adding support here is not a breaking change.