### PR TITLE
Add SubscriptionChange trigger to webhook configuration

### DIFF
--- a/src/Postmark.Tests/ClientWebhookTests.cs
+++ b/src/Postmark.Tests/ClientWebhookTests.cs
@@ -40,7 +40,9 @@ namespace Postmark.Tests
                 Click = new WebhookConfigurationClickTrigger {Enabled = true},
                 Open = new WebhookConfigurationOpenTrigger {Enabled = true, PostFirstOpenOnly = true},
                 Delivery = new WebhookConfigurationDeliveryTrigger {Enabled = true},
-                SpamComplaint = new WebhookConfigurationSpamComplaintTrigger {Enabled = true, IncludeContent = true}
+                SpamComplaint = new WebhookConfigurationSpamComplaintTrigger {Enabled = true, IncludeContent = true},
+                SubscriptionChange = new WebhookConfigurationSubscriptionChangeTrigger {Enabled = true},
+
             };
             var newConfiguration = await Client.CreateWebhookConfigurationAsync(url, messageStream, httpAuth, httpHeaders, triggers);
 
@@ -59,6 +61,7 @@ namespace Postmark.Tests
             Assert.Equal(triggers.Delivery.Enabled, newConfiguration.Triggers.Delivery.Enabled);
             Assert.Equal(triggers.SpamComplaint.Enabled, newConfiguration.Triggers.SpamComplaint.Enabled);
             Assert.Equal(triggers.SpamComplaint.IncludeContent, newConfiguration.Triggers.SpamComplaint.IncludeContent);
+            Assert.Equal(triggers.SubscriptionChange.Enabled, newConfiguration.Triggers.SubscriptionChange.Enabled);
         }
 
         [Fact]

--- a/src/Postmark/Model/Webhooks/WebhookConfigurationSubscriptionChangeTrigger.cs
+++ b/src/Postmark/Model/Webhooks/WebhookConfigurationSubscriptionChangeTrigger.cs
@@ -1,0 +1,13 @@
+namespace PostmarkDotNet.Model.Webhooks
+{
+    /// <summary>
+    /// Settings for SubscriptionChange webhooks
+    /// </summary>
+    public class WebhookConfigurationSubscriptionChangeTrigger
+    {
+        /// <summary>
+        /// Specifies whether or not webhooks will be triggered by SubscriptionChange events
+        /// </summary>
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/Postmark/Model/Webhooks/WebhookConfigurationTriggers.cs
+++ b/src/Postmark/Model/Webhooks/WebhookConfigurationTriggers.cs
@@ -29,5 +29,10 @@
         /// Settings for SpamComplaint webhooks
         /// </summary>
         public WebhookConfigurationSpamComplaintTrigger SpamComplaint { get; set; }
+
+        /// <summary>
+        /// Settings for SubscriptionChange webhooks
+        /// </summary>
+        public WebhookConfigurationSubscriptionChangeTrigger SubscriptionChange { get; set; }
     }
 }


### PR DESCRIPTION
It is documented in the [API docs](https://postmarkapp.com/developer/webhooks/subscription-change-webhook), but is not implemented in the SDK.

I have implemented additional testing, but was unable to run it as it looks like a Selenium instance is required. I'm hoping the automated test suite here will verify my changes.

Fixes #110.