### PR TITLE
Update return type for GetInboundMessageDetailsAsync method

### DIFF
--- a/src/Postmark/LegacyClientExtensions.cs
+++ b/src/Postmark/LegacyClientExtensions.cs
@@ -467,7 +467,7 @@ namespace PostmarkDotNet.Legacy
             return Task.Run(async () => await client.GetInboundMessagesAsync(offset, count, recipient, fromemail, subject, mailboxhash)).Result;
         }
 
-        public static InboundMessageDetail GetInboundMessageDetail(this PostmarkClient client, string messageID)
+        public static PostmarkInboundMessage GetInboundMessageDetail(this PostmarkClient client, string messageID)
         {
             return Task.Run(async () => await client.GetInboundMessageDetailsAsync(messageID)).Result;
         }

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -250,9 +250,9 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="messageID">The MessageID of a message which can be optained either from the initial API send call or a GetInboundMessages call.</param>
         /// <returns>InboundMessageDetail</returns>
-        public async Task<InboundMessageDetail> GetInboundMessageDetailsAsync(string messageID)
+        public async Task<PostmarkInboundMessage> GetInboundMessageDetailsAsync(string messageID)
         {
-            return await ProcessNoBodyRequestAsync<InboundMessageDetail>("/messages/inbound/" + messageID + "/details");
+            return await ProcessNoBodyRequestAsync<PostmarkInboundMessage>("/messages/inbound/" + messageID + "/details");
         }
 
         /// <summary>


### PR DESCRIPTION
The return type for the GetInboundMessageDetailsAsync method in both the PostmarkClient class and LegacyClientExtensions class has been updated. It has been changed from InboundMessageDetail to PostmarkInboundMessage to use the newer model to include Content on the attachments